### PR TITLE
Add alert policy and autoresolve

### DIFF
--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -426,7 +426,7 @@ class Pingdom(object):
         if checktype == 'http':
             # Warn user about unhandled parameters
             for key in kwargs:
-                if key not in ['alert_policy', 'paused', 'resolution', 'contactids',
+                if key not in ['alert_policy', 'autoresolve', 'paused', 'resolution', 'contactids',
                                'sendtoemail', 'sendtosms', 'sendtotwitter',
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
@@ -454,7 +454,7 @@ class Pingdom(object):
         elif checktype == 'tcp':
             # Warn user about unhandled parameters
             for key in kwargs:
-                if key not in ['alert_policy', 'paused', 'resolution', 'contactids',
+                if key not in ['alert_policy', 'autoresolve', 'paused', 'resolution', 'contactids',
                                'sendtoemail', 'sendtosms', 'sendtotwitter',
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',

--- a/pingdomlib/pingdom.py
+++ b/pingdomlib/pingdom.py
@@ -426,7 +426,7 @@ class Pingdom(object):
         if checktype == 'http':
             # Warn user about unhandled parameters
             for key in kwargs:
-                if key not in ['paused', 'resolution', 'contactids',
+                if key not in ['alert_policy', 'paused', 'resolution', 'contactids',
                                'sendtoemail', 'sendtosms', 'sendtotwitter',
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',
@@ -454,7 +454,7 @@ class Pingdom(object):
         elif checktype == 'tcp':
             # Warn user about unhandled parameters
             for key in kwargs:
-                if key not in ['paused', 'resolution', 'contactids',
+                if key not in ['alert_policy', 'paused', 'resolution', 'contactids',
                                'sendtoemail', 'sendtosms', 'sendtotwitter',
                                'sendtoiphone', 'sendtoandroid',
                                'sendnotificationwhendown', 'notifyagainevery',


### PR DESCRIPTION
To set alert_policy using the alert policy id. Can't set the policy by
name so this will have to do. To find the id, open the policy in the
pingdom admin panel and look for /alertgroups/edit/xxxxx in the URL.

Also adds autoresolve
